### PR TITLE
Add null check for destructor

### DIFF
--- a/src/main/java/xasmedy/bettercommands/commands/admin/fun/DestructorCommand.java
+++ b/src/main/java/xasmedy/bettercommands/commands/admin/fun/DestructorCommand.java
@@ -78,7 +78,9 @@ public class DestructorCommand extends AbstractCommand {
     }
 
     public void turboDestructor(Player player) {
-
+        
+        if (player.unit() == null) return;
+        
         circle.set(player.x(), player.y(), Math.max(player.unit().hitSize() * 3f, 100f)); // adjust as needed
 
         float pointCount = 50f; // adjust as needed

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -3,5 +3,5 @@
   "author": "Xasmedy",
   "main": "xasmedy.bettercommands.BetterCommands",
   "description": "Add some console commands and even new commands!",
-  "version": "0.8v"
+  "version": "0.7.1v"
 }

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -3,5 +3,5 @@
   "author": "Xasmedy",
   "main": "xasmedy.bettercommands.BetterCommands",
   "description": "Add some console commands and even new commands!",
-  "version": "0.7v"
+  "version": "0.8v"
 }


### PR DESCRIPTION
It crashes the server otherwise.

Original error:
```
[02-03-2026 17:13:58] [E] java.lang.NullPointerException: Cannot invoke "mindustry.gen.Unit.hitSize()" because the return value of "mindustry.gen.Player.unit()" is null
	at xasmedy.bettercommands.commands.admin.fun.DestructorCommand.turboDestructor(DestructorCommand.java:82)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at xasmedy.bettercommands.commands.admin.fun.DestructorCommand.runTick(DestructorCommand.java:108)
	at xasmedy.bettercommands.Util$1.update(Util.java:46)
	at arc.backend.headless.HeadlessApplication.mainLoop(HeadlessApplication.java:87)
	at arc.backend.headless.HeadlessApplication$1.run(HeadlessApplication.java:52)
```